### PR TITLE
feat(desktop): 支持仅自动填答案，保留手动确认提交

### DIFF
--- a/ykt-helper-win/apps/desktop/renderer/src/components/AssistantPanel.vue
+++ b/ykt-helper-win/apps/desktop/renderer/src/components/AssistantPanel.vue
@@ -146,6 +146,11 @@ const lessons = ref<readonly Lesson[]>([]);
 const selectedLessonId = ref('');
 const problems = ref<readonly ProblemContext[]>([]);
 const selectedProblemId = ref('');
+const autoFilledDrafts = new Map<
+  string,
+  { draft: string; proposal: AnswerProposal }
+>();
+let automaticAnalysisRunning = false;
 const presentations = ref<readonly Presentation[]>([]);
 const selectedPresentationId = ref('');
 const selectedSlideId = ref('');
@@ -402,7 +407,9 @@ watch(
   },
 );
 
-watch(selectedProblemId, (id) => {
+watch(selectedProblemId, (id, previousId) => {
+  const saved = autoFilledDrafts.get(previousId);
+  if (saved) saved.draft = answerDraft.value;
   if (id) aiSlideContextId.value = '';
   resetAnswer();
 });
@@ -632,16 +639,22 @@ async function submitAnswer(): Promise<void> {
 }
 
 function resetAnswer(): void {
+  const saved =
+    selectedProblem.value?.status === 'available'
+      ? autoFilledDrafts.get(selectedProblemId.value)
+      : undefined;
   const result = selectedProblem.value?.result;
-  answerDraft.value = !result
-    ? ''
-    : Array.isArray(result)
-      ? result.join('')
-      : (result as { content: string }).content;
+  answerDraft.value = saved
+    ? saved.draft
+    : !result
+      ? ''
+      : Array.isArray(result)
+        ? result.join('')
+        : (result as { content: string }).content;
   validation.value = undefined;
   aiProposal.value = latestSessionProposal(currentAiSession.value);
   aiChatDraft.value = '';
-  appliedProposalId.value = '';
+  appliedProposalId.value = saved?.proposal.id ?? '';
   confirmed.value = false;
   submissionMessage.value = '';
 }
@@ -817,6 +830,7 @@ async function requestAiProposal(
   auto: boolean,
   retry: boolean,
 ): Promise<void> {
+  const managedSubmitAtStart = agentAutoSubmitEnabled.value;
   clearMessages();
   let session = aiChatSessions.get(contextId);
   if (!session) {
@@ -912,13 +926,32 @@ async function requestAiProposal(
   }
 
   if (!problem) return;
-  if (agentAutoSubmitEnabled.value) {
+  if (managedSubmitAtStart && agentAutoSubmitEnabled.value) {
     await applyAutomaticProposal(problem, proposal);
     return;
   }
+  const current = problems.value.find((item) => item.id === problem.id);
+  if (
+    selectedLessonId.value !== problem.lessonId ||
+    current?.status !== 'available' ||
+    (current.deadlineAt && current.deadlineAt <= Date.now())
+  )
+    return;
+  if (proposal.status === 'ready' && proposal.answer) {
+    const draft = answerValueToDraft(proposal.answer, problem.type);
+    autoFilledDrafts.set(problem.id, { draft, proposal });
+    if (selectedProblemId.value === problem.id) {
+      answerDraft.value = draft;
+      appliedProposalId.value = proposal.id;
+      validation.value = undefined;
+      confirmed.value = false;
+      submissionMessage.value = '';
+      emit('selectPage', 'problems');
+    }
+  }
   infoMessage.value =
     proposal.status === 'ready'
-      ? 'LLM 已生成答案，等待手动核对。'
+      ? 'LLM 已填入答案，尚未提交，等待手动核对、校验并确认提交。'
       : proposal.failureReason || 'LLM 未生成可用答案。';
   await emitLocalNotice(
     proposal.status === 'ready'
@@ -1473,19 +1506,35 @@ async function onAvailableProblem(problem: ProblemContext): Promise<void> {
     'LLM 答案生成已排队',
     `${Math.ceil(delay / 1000)} 秒后开始分析。`,
   );
-  const timer = setTimeout(() => {
-    scheduledProblems.delete(problem.id);
+  const startAnalysis = async (): Promise<void> => {
     const current = problems.value.find((item) => item.id === problem.id);
     if (
       !settings.value?.llmAutoGenerate ||
       current?.status !== 'available' ||
       (current.deadlineAt && current.deadlineAt <= Date.now())
-    )
+    ) {
+      scheduledProblems.delete(problem.id);
       return;
+    }
+    if (busy.value || aiRequestPending.value || automaticAnalysisRunning) {
+      scheduledProblems.set(
+        problem.id,
+        setTimeout(() => void startAnalysis(), 500),
+      );
+      return;
+    }
+    scheduledProblems.delete(problem.id);
+    automaticAnalysisRunning = true;
     selectedProblemId.value = current.id;
     aiSlideSelection.value = [];
-    void nextTick(() => analyzeProblem(true));
-  }, delay);
+    try {
+      await nextTick();
+      await analyzeProblem(true);
+    } finally {
+      automaticAnalysisRunning = false;
+    }
+  };
+  const timer = setTimeout(() => void startAnalysis(), delay);
   scheduledProblems.set(problem.id, timer);
 }
 
@@ -2748,8 +2797,8 @@ function clamp(value: number, min: number, max: number): number {
                 <span>
                   <strong>LLM 托管提交答案</strong>
                   <small
-                    >生成成功后由 Agent 校验并提交；关闭时仅保留 AI
-                    回答。</small
+                    >生成成功后由 Agent
+                    校验并提交；关闭时自动填入答案草稿，等待手动核对提交。</small
                   >
                 </span>
                 <input

--- a/ykt-helper-win/tests/contract/auto-fill.test.ts
+++ b/ykt-helper-win/tests/contract/auto-fill.test.ts
@@ -1,0 +1,300 @@
+import { effectScope, nextTick } from 'vue';
+import type * as Vue from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DefaultAppSettings, ProblemType } from '@ykt/contracts';
+import { createBackendRuntime } from '@ykt/backend';
+import AssistantPanel from '../../apps/desktop/renderer/src/components/AssistantPanel.vue';
+
+vi.mock('vue', async (importOriginal) => ({
+  ...(await importOriginal<typeof Vue>()),
+  onMounted: vi.fn(),
+  onUnmounted: vi.fn(),
+  useSSRContext: () => ({ modules: new Set() }),
+}));
+
+const scopes: ReturnType<typeof effectScope>[] = [];
+afterEach(() => {
+  scopes.splice(0).forEach((scope) => scope.stop());
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function setupPanel() {
+  vi.useFakeTimers();
+  const api = {
+    generateAnswerProposal: vi.fn(async ({ problemId }) => ({
+      id: `proposal-${problemId}`,
+      problemId,
+      status: 'ready',
+      answer: ['A', 'C'],
+    })),
+    validateAnswer: vi.fn(async () => ({ valid: true, issues: [] })),
+    submitAnswer: vi.fn(async () => ({
+      submittedAt: new Date().toISOString(),
+    })),
+    listProblems: vi.fn(async () => []),
+    listPresentations: vi.fn(async () => []),
+    updateSettings: vi.fn(async (patch) => ({
+      ...DefaultAppSettings,
+      ...patch,
+    })),
+  };
+  vi.stubGlobal('window', { yuketang: api });
+  const emit = vi.fn();
+  const scope = effectScope();
+  scopes.push(scope);
+  const panel = scope.run(() =>
+    (AssistantPanel as any).setup(
+      { page: 'classroom', environment: 'changjiang' },
+      { expose: vi.fn(), emit },
+    ),
+  );
+  panel.applySettings({
+    ...DefaultAppSettings,
+    llmAutoGenerate: true,
+    llmManagedSubmit: false,
+    notifyProblems: false,
+  });
+  const problem = {
+    id: 'p1',
+    lessonId: 'l1',
+    type: ProblemType.MultipleChoice,
+    status: 'available',
+    prompt: 'Select options',
+    options: ['one', 'two', 'three'],
+  };
+  panel.problems.value = [problem];
+  panel.selectedLessonId.value = 'l1';
+  return { panel, api, problem, emit };
+}
+
+describe('automatic draft-only answers', () => {
+  it('requires validation and explicit user confirmation before manual submission', async () => {
+    const { panel, api, problem } = setupPanel();
+    await panel.onAvailableProblem(problem);
+    await vi.advanceTimersByTimeAsync(6000);
+    await panel.submitAnswer();
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+    await panel.validateAnswer();
+    await panel.submitAnswer();
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+    panel.confirmed.value = true;
+    await panel.submitAnswer();
+    expect(api.submitAnswer).toHaveBeenCalledExactlyOnceWith({
+      problemId: 'p1',
+      answer: 'AC',
+      proposalId: 'proposal-p1',
+      confirmedBy: 'user',
+    });
+  });
+
+  it('does not fill or submit when the model fails', async () => {
+    const { panel, api, problem } = setupPanel();
+    api.generateAnswerProposal.mockRejectedValueOnce(
+      new Error('model unavailable'),
+    );
+    await panel.onAvailableProblem(problem);
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(panel.answerDraft.value).toBe('');
+    expect(panel.currentAiSession.value.messages.at(-1).content).toBe(
+      'model unavailable',
+    );
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+  });
+
+  it('cancels pending work when the feature is disabled', async () => {
+    const { panel, api, problem } = setupPanel();
+    await panel.onAvailableProblem(problem);
+    panel.settings.value.llmAutoGenerate = false;
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(api.generateAnswerProposal).not.toHaveBeenCalled();
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+  });
+
+  it('selects a new question and fills options without validating or submitting', async () => {
+    const { panel, api, problem, emit } = setupPanel();
+    await panel.onAvailableProblem(problem);
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(panel.selectedProblemId.value).toBe('p1');
+    expect(panel.selectedLetters.value).toEqual(['A', 'C']);
+    expect(panel.confirmed.value).toBe(false);
+    expect(panel.canSubmit.value).toBe(false);
+    expect(emit).toHaveBeenCalledWith('selectPage', 'problems');
+    expect(api.validateAnswer).not.toHaveBeenCalled();
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+    expect(panel.infoMessage.value).toContain('尚未提交');
+  });
+
+  it('waits while busy and preserves separate drafts for multiple questions', async () => {
+    const { panel, api, problem } = setupPanel();
+    const second = { ...problem, id: 'p2' };
+    panel.problems.value.push(second);
+    panel.busy.value = 'settings';
+    await panel.onAvailableProblem(problem);
+    await panel.onAvailableProblem(second);
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(api.generateAnswerProposal).not.toHaveBeenCalled();
+    panel.busy.value = '';
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(api.generateAnswerProposal).toHaveBeenCalledTimes(2);
+    panel.selectedProblemId.value = 'p1';
+    await nextTick();
+    expect(panel.answerDraft.value).toBe('AC');
+    panel.answerDraft.value = 'B';
+    await nextTick();
+    panel.selectedProblemId.value = 'p2';
+    await nextTick();
+    expect(panel.answerDraft.value).toBe('AC');
+    panel.selectedProblemId.value = 'p1';
+    await nextTick();
+    expect(panel.answerDraft.value).toBe('B');
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+  });
+
+  it('keeps in-flight draft-only analysis from submitting after the mode changes', async () => {
+    const { panel, api, problem } = setupPanel();
+    panel.selectedProblemId.value = problem.id;
+    await nextTick();
+    let resolve!: (value: any) => void;
+    api.generateAnswerProposal.mockImplementationOnce(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const analysis = panel.analyzeProblem(true);
+    panel.settings.value.llmManagedSubmit = true;
+    resolve({
+      id: 'proposal-p1',
+      problemId: 'p1',
+      status: 'ready',
+      answer: ['B'],
+    });
+    await analysis;
+    expect(panel.answerDraft.value).toBe('B');
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+  });
+
+  it('serializes overlapping automatic requests and keeps both drafts', async () => {
+    const { panel, api, problem } = setupPanel();
+    const second = { ...problem, id: 'p2' };
+    panel.problems.value.push(second);
+    let resolve!: (value: any) => void;
+    api.generateAnswerProposal.mockImplementationOnce(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    await panel.onAvailableProblem(problem);
+    await panel.onAvailableProblem(second);
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(api.generateAnswerProposal).toHaveBeenCalledTimes(1);
+    expect(panel.selectedProblemId.value).toBe('p1');
+    resolve({
+      id: 'proposal-p1',
+      problemId: 'p1',
+      status: 'ready',
+      answer: ['B'],
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(api.generateAnswerProposal).toHaveBeenCalledTimes(2);
+    expect(panel.answerDraft.value).toBe('AC');
+    panel.selectedProblemId.value = 'p1';
+    await nextTick();
+    expect(panel.answerDraft.value).toBe('B');
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+  });
+
+  it.each(['lesson changed', 'deadline passed'])(
+    'does not prefill after %s while AI is pending',
+    async (reason) => {
+      const { panel, api, problem, emit } = setupPanel();
+      panel.selectedProblemId.value = problem.id;
+      await nextTick();
+      let resolve!: (value: any) => void;
+      api.generateAnswerProposal.mockImplementationOnce(
+        () =>
+          new Promise((done) => {
+            resolve = done;
+          }),
+      );
+      const analysis = panel.analyzeProblem(true);
+      if (reason === 'lesson changed') panel.selectedLessonId.value = 'l2';
+      else panel.problems.value = [{ ...problem, deadlineAt: Date.now() - 1 }];
+      resolve({
+        id: 'proposal-p1',
+        problemId: 'p1',
+        status: 'ready',
+        answer: ['A'],
+      });
+      await analysis;
+      expect(panel.answerDraft.value).toBe('');
+      expect(emit).not.toHaveBeenCalledWith('selectPage', 'problems');
+      expect(api.submitAnswer).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not overwrite another question when an AI response arrives late', async () => {
+    const { panel, api, problem } = setupPanel();
+    panel.problems.value.push({ ...problem, id: 'p2' });
+    panel.selectedProblemId.value = problem.id;
+    await nextTick();
+    let resolve!: (value: any) => void;
+    api.generateAnswerProposal.mockImplementationOnce(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const analysis = panel.analyzeProblem(true);
+    panel.selectedProblemId.value = 'p2';
+    await nextTick();
+    panel.answerDraft.value = 'B';
+    resolve({
+      id: 'proposal-p1',
+      problemId: 'p1',
+      status: 'ready',
+      answer: ['A'],
+    });
+    await analysis;
+    expect(panel.answerDraft.value).toBe('B');
+    expect(api.submitAnswer).not.toHaveBeenCalled();
+    panel.selectedProblemId.value = 'p1';
+    await nextTick();
+    expect(panel.answerDraft.value).toBe('A');
+    expect(panel.appliedProposalId.value).toBe('proposal-p1');
+  });
+
+  it('persists generation without managed submission using upstream settings', async () => {
+    const { panel, api } = setupPanel();
+    await panel.saveSettings();
+    expect(api.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        llmAutoGenerate: true,
+        llmManagedSubmit: false,
+      }),
+    );
+  });
+
+  it('blocks agent submissions at the backend while leaving user submissions available', async () => {
+    const runtime = createBackendRuntime();
+    await runtime.start();
+    await runtime.facade.updateSettings({
+      llmAutoGenerate: true,
+      llmManagedSubmit: false,
+    });
+    const input = { problemId: 'missing', answer: ['A'] };
+    await expect(
+      runtime.facade.submitAnswer({ ...input, confirmedBy: 'agent' }),
+    ).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+    await expect(
+      runtime.facade.submitAnswer({ ...input, confirmedBy: 'user' }),
+    ).rejects.not.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+    await runtime.stop();
+  });
+});


### PR DESCRIPTION
开启 LLM 自动生成、关闭托管提交时，现有流程只保留 AI 回复，仍需手动采用建议。本 PR 将生成的答案填入助手题目页，提示“尚未提交”，由用户核对、校验并确认提交；切换题目后保留各题草稿及用户修改。

Refs #35

## 改动

- 基于 `4353711337c50e1bf9e5a7cb1365fe4662bdcc6b`，目标分支为 `feat/dev3.0`。沿用 `llmAutoGenerate` 和 `llmManagedSubmit`，不新增设置字段。
- 在上游按题保存 AI 对话的结构中加入答案草稿，预填当前题后切换至题目页。迟到的回复可保存到对应题的草稿，不覆盖当前另一题的答案；切换课堂或题目过期后不预填。
- 排队任务等待当前操作及自动分析完成，避免多个自动请求争用当前题目；执行前复查自动生成开关、题目状态和截止时间。
- 请求开始时记录托管提交是否开启，以仅预填方式开始的请求不会因中途开启托管而自动提交。后端提交权限沿用上游实现。
- 新增 12 项行为测试，覆盖预填、手动确认、多题草稿、AI 失败、取消排队、请求重叠、模式切换、迟到回复、切换课堂、题目过期、设置保存和后端提交限制。

## 验证

在 Windows、Node.js 24.15.0 下完成：

- `npm test`：20 个测试文件通过，85 项测试通过；1 项 Unix socket 测试在 Windows 上按设计跳过。
- `npm run build` 通过，包含桌面端和 CLI。
- `npm run lint` 通过，包含依赖边界检查。
- `git diff --check` 通过。

上述检查针对本 PR 提交 `26b3979`。AI 调用和提交使用测试替身，尚未连接真实课堂做端到端验证。

实现与测试使用 Codex 辅助。
